### PR TITLE
Reduce mutation observers to prevent freeze

### DIFF
--- a/pages/content/src/autofill-engine/data-inserter.ts
+++ b/pages/content/src/autofill-engine/data-inserter.ts
@@ -26,9 +26,9 @@ export class DataInserter {
    * Insert data into a form field
    */
   async insertData(
-    field: FormField, 
-    value: any, 
-    source: 'profile' | 'ai' | 'default_answer' = 'profile'
+    field: FormField,
+    value: any,
+    source: 'profile' | 'ai' | 'default_answer' = 'profile',
   ): Promise<InsertionResult> {
     try {
       const element = this.findElement(field.selector);
@@ -38,8 +38,8 @@ export class DataInserter {
           error: {
             code: 'ELEMENT_NOT_FOUND',
             message: `Element not found for selector: ${field.selector}`,
-            recoverable: true
-          }
+            recoverable: true,
+          },
         };
       }
 
@@ -91,8 +91,8 @@ export class DataInserter {
             error: {
               code: 'UNSUPPORTED_OPERATION',
               message: 'File insertion should be handled by AutofillEngine using FileUploadHandler',
-              recoverable: false
-            }
+              recoverable: false,
+            },
           };
 
         default:
@@ -101,8 +101,8 @@ export class DataInserter {
             error: {
               code: 'UNSUPPORTED_FIELD_TYPE',
               message: `Unsupported field type: ${field.type}`,
-              recoverable: false
-            }
+              recoverable: false,
+            },
           };
       }
 
@@ -116,8 +116,8 @@ export class DataInserter {
             fieldId: field.id,
             selector: field.selector,
             value: finalValue,
-            source
-          }
+            source,
+          },
         };
       } else {
         return {
@@ -125,19 +125,18 @@ export class DataInserter {
           error: {
             code: 'INSERTION_FAILED',
             message: `Failed to insert value into ${field.type} field`,
-            recoverable: true
-          }
+            recoverable: true,
+          },
         };
       }
-
     } catch (error) {
       return {
         success: false,
         error: {
           code: 'UNEXPECTED_ERROR',
           message: error instanceof Error ? error.message : 'Unknown error occurred',
-          recoverable: true
-        }
+          recoverable: true,
+        },
       };
     }
   }
@@ -191,7 +190,7 @@ export class DataInserter {
         const option = element.options[i];
         const optionText = option.text.toLowerCase();
         const optionValue = option.value.toLowerCase();
-        
+
         if (optionText.includes(normalizedValue) || optionValue.includes(normalizedValue)) {
           element.selectedIndex = i;
           return true;
@@ -219,7 +218,7 @@ export class DataInserter {
     return this.withRetry(async () => {
       // Find all radio buttons with the same name
       const radioButtons = document.querySelectorAll(`input[type="radio"]${selector}`) as NodeListOf<HTMLInputElement>;
-      
+
       for (const radio of radioButtons) {
         if (radio.value === value || radio.nextElementSibling?.textContent?.trim() === value) {
           radio.checked = true;
@@ -232,7 +231,7 @@ export class DataInserter {
       for (const radio of radioButtons) {
         const radioValue = radio.value.toLowerCase();
         const radioLabel = radio.nextElementSibling?.textContent?.trim().toLowerCase() || '';
-        
+
         if (radioValue.includes(normalizedValue) || radioLabel.includes(normalizedValue)) {
           radio.checked = true;
           return true;
@@ -250,7 +249,7 @@ export class DataInserter {
     return this.withRetry(async () => {
       // Try to parse and format date
       let formattedDate = value;
-      
+
       if (value && !value.match(/^\d{4}-\d{2}-\d{2}$/)) {
         try {
           const date = new Date(value);
@@ -280,7 +279,7 @@ export class DataInserter {
       `[name="${selector}"]`,
       `[id="${selector}"]`,
       `[data-testid="${selector}"]`,
-      `[aria-label*="${selector}"]`
+      `[aria-label*="${selector}"]`,
     ];
 
     for (const fallbackSelector of fallbackSelectors) {
@@ -295,7 +294,7 @@ export class DataInserter {
    * Wait for element to be ready for interaction
    */
   private async waitForElementReady(element: Element): Promise<void> {
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       if (this.isElementReady(element)) {
         resolve();
         return;
@@ -310,7 +309,8 @@ export class DataInserter {
 
       observer.observe(element, {
         attributes: true,
-        attributeFilter: ['disabled', 'readonly', 'style']
+        // Watching style mutations can trigger excessive callbacks; limit to required attributes.
+        attributeFilter: ['disabled', 'readonly'],
       });
 
       // Timeout after 2 seconds
@@ -334,11 +334,11 @@ export class DataInserter {
    */
   private async triggerChangeEvents(element: Element): Promise<void> {
     const events = ['input', 'change', 'blur'];
-    
+
     for (const eventType of events) {
       const event = new Event(eventType, { bubbles: true, cancelable: true });
       element.dispatchEvent(event);
-      
+
       // Small delay between events
       await new Promise(resolve => setTimeout(resolve, 10));
     }
@@ -355,11 +355,9 @@ export class DataInserter {
         return await operation();
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
-        
+
         if (attempt < DataInserter.RETRY_ATTEMPTS) {
-          await new Promise(resolve => 
-            setTimeout(resolve, DataInserter.RETRY_DELAY * Math.pow(2, attempt - 1))
-          );
+          await new Promise(resolve => setTimeout(resolve, DataInserter.RETRY_DELAY * Math.pow(2, attempt - 1)));
         }
       }
     }

--- a/pages/content/src/job-form-detector.ts
+++ b/pages/content/src/job-form-detector.ts
@@ -16,16 +16,16 @@ export class JobFormDetector {
    */
   startMonitoring(): void {
     console.log('[Job Autofill] Starting form detection...');
-    
+
     // Initial scan
     this.scanForForms();
-    
+
     // Start observing DOM changes
     this.observer?.observe(document.body, {
       childList: true,
       subtree: true,
-      attributes: true,
-      attributeFilter: ['class', 'id']
+      // Watching attribute changes for every node is expensive and unnecessary here
+      // since the detector only reacts to added/removed elements.
     });
 
     // Also scan when page is fully loaded
@@ -41,7 +41,7 @@ export class JobFormDetector {
    */
   private handleMutations(mutations: MutationRecord[]): void {
     let shouldScan = false;
-    
+
     for (const mutation of mutations) {
       if (mutation.type === 'childList') {
         // Check if any added nodes contain forms
@@ -68,7 +68,7 @@ export class JobFormDetector {
    */
   private scanForForms(): void {
     const forms = document.querySelectorAll('form');
-    
+
     forms.forEach(form => {
       if (!this.detectedForms.has(form) && this.isJobApplicationForm(form)) {
         console.log('[Job Autofill] Job application form detected:', form);
@@ -88,16 +88,27 @@ export class JobFormDetector {
     const formHTML = form.innerHTML.toLowerCase();
     const formAction = form.action.toLowerCase();
     const formClasses = form.className.toLowerCase();
-    
+
     // Check for job application indicators
     const jobKeywords = [
-      'job_application', 'application', 'apply', 'career', 'resume', 
-      'cover_letter', 'position', 'employment', 'candidate'
+      'job_application',
+      'application',
+      'apply',
+      'career',
+      'resume',
+      'cover_letter',
+      'position',
+      'employment',
+      'candidate',
     ];
-    
+
     const questionKeywords = [
-      'why are you interested', 'tell us about', 'describe your experience',
-      'what makes you', 'why do you want', 'interesting project'
+      'why are you interested',
+      'tell us about',
+      'describe your experience',
+      'what makes you',
+      'why do you want',
+      'interesting project',
     ];
 
     // Check form action URL
@@ -143,7 +154,7 @@ export class JobFormDetector {
    */
   private scanForJobQuestionFields(): void {
     const textareas = document.querySelectorAll('textarea');
-    
+
     textareas.forEach(textarea => {
       if (this.isJobQuestionField(textarea)) {
         this.injectFieldUI(textarea);
@@ -159,14 +170,18 @@ export class JobFormDetector {
     if (!label) return false;
 
     const questionKeywords = [
-      'why are you interested', 'tell us about', 'describe your experience',
-      'what makes you', 'why do you want', 'interesting project',
-      'most challenging', 'greatest achievement', 'cover letter'
+      'why are you interested',
+      'tell us about',
+      'describe your experience',
+      'what makes you',
+      'why do you want',
+      'interesting project',
+      'most challenging',
+      'greatest achievement',
+      'cover letter',
     ];
 
-    return questionKeywords.some(keyword => 
-      label.toLowerCase().includes(keyword)
-    );
+    return questionKeywords.some(keyword => label.toLowerCase().includes(keyword));
   }
 
   /**
@@ -195,7 +210,7 @@ export class JobFormDetector {
       if (label) {
         return label.textContent || '';
       }
-      
+
       // Look for text content in parent
       const textContent = parent.textContent || '';
       return textContent.slice(0, 200); // Limit length
@@ -214,12 +229,12 @@ export class JobFormDetector {
     button.style.top = '10px';
     button.style.right = '10px';
     button.style.zIndex = '10000';
-    
+
     // Position relative to form
     const formRect = form.getBoundingClientRect();
     button.style.left = `${formRect.right - 150}px`;
     button.style.top = `${formRect.top + window.scrollY - 40}px`;
-    
+
     document.body.appendChild(button);
     this.injectedElements.add(button);
 
@@ -239,14 +254,14 @@ export class JobFormDetector {
 
     // Create AI assist button
     const button = this.createAIAssistButton();
-    
+
     // Position next to the field
     const fieldRect = field.getBoundingClientRect();
     button.style.position = 'absolute';
     button.style.left = `${fieldRect.right + window.scrollX + 10}px`;
     button.style.top = `${fieldRect.top + window.scrollY}px`;
     button.style.zIndex = '10000';
-    
+
     document.body.appendChild(button);
     this.injectedElements.add(button);
 
@@ -285,12 +300,12 @@ export class JobFormDetector {
       transition: all 0.2s;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     `;
-    
+
     button.addEventListener('mouseenter', () => {
       button.style.background = '#1d4ed8';
       button.style.transform = 'translateY(-1px)';
     });
-    
+
     button.addEventListener('mouseleave', () => {
       button.style.background = '#2563eb';
       button.style.transform = 'translateY(0)';
@@ -319,12 +334,12 @@ export class JobFormDetector {
       transition: all 0.2s;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     `;
-    
+
     button.addEventListener('mouseenter', () => {
       button.style.background = '#6d28d9';
       button.style.transform = 'translateY(-1px)';
     });
-    
+
     button.addEventListener('mouseleave', () => {
       button.style.background = '#7c3aed';
       button.style.transform = 'translateY(0)';
@@ -338,10 +353,10 @@ export class JobFormDetector {
    */
   private handleAutofillClick(form: HTMLFormElement): void {
     console.log('[Job Autofill] Autofill clicked for form:', form);
-    
+
     // Show notification
     this.showNotification('Autofill feature coming soon!', 'info');
-    
+
     // Send message to background script
     chrome.runtime.sendMessage({
       type: 'form:detected',
@@ -351,10 +366,10 @@ export class JobFormDetector {
         platform: this.detectPlatform(),
         fieldCount: form.querySelectorAll('input, textarea, select').length,
         confidence: 0.8,
-        url: window.location.href
+        url: window.location.href,
       },
       id: `content_${Date.now()}`,
-      timestamp: Date.now()
+      timestamp: Date.now(),
     });
   }
 
@@ -363,7 +378,7 @@ export class JobFormDetector {
    */
   private handleAIAssistClick(field: HTMLTextAreaElement): void {
     console.log('[Job Autofill] AI assist clicked for field:', field);
-    
+
     const label = this.getFieldLabel(field);
     this.showNotification(`AI assistance for: "${label.slice(0, 50)}..." - Coming soon!`, 'info');
   }
@@ -389,9 +404,9 @@ export class JobFormDetector {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       max-width: 300px;
     `;
-    
+
     document.body.appendChild(notification);
-    
+
     // Remove after 3 seconds
     setTimeout(() => {
       if (notification.parentNode) {
@@ -412,11 +427,11 @@ export class JobFormDetector {
    */
   private detectPlatform(): string {
     const hostname = window.location.hostname.toLowerCase();
-    
+
     if (hostname.includes('linkedin.com')) return 'linkedin';
     if (hostname.includes('indeed.com')) return 'indeed';
     if (hostname.includes('workday.com')) return 'workday';
-    
+
     return 'custom';
   }
 
@@ -425,14 +440,14 @@ export class JobFormDetector {
    */
   stopMonitoring(): void {
     this.observer?.disconnect();
-    
+
     // Remove injected elements
     this.injectedElements.forEach(element => {
       if (element.parentNode) {
         element.parentNode.removeChild(element);
       }
     });
-    
+
     this.injectedElements.clear();
     this.detectedForms.clear();
   }


### PR DESCRIPTION
## Summary
- limit mutation observer attribute filters to required fields to avoid excessive DOM change events
- simplify job form detector observer to ignore attribute mutations
- reduce element readiness watcher to essential attributes only

## Testing
- `pnpm lint` (fails: run failed: command exited (1))

------
https://chatgpt.com/codex/tasks/task_e_68a8620c0c64832096b3ffb766a7e1b4